### PR TITLE
Use dark text color for light swatches

### DIFF
--- a/src/components/ColorSwatches.js
+++ b/src/components/ColorSwatches.js
@@ -16,7 +16,7 @@ const Swatches = (props) => {
       <SwatchBook>
         {props.colorList.map((color, i) =>
           <Swatch key={`c-list_${color.index}-${i}`} style={returnStyle(color.hex)}>
-            <SwatchLink to={`/swatch/${color.slug}`}>
+            <SwatchLink to={`/swatch/${color.slug}`} hex={color.hex}>
               <p className={'index'}>{color.index}</p>
               <p className={'name'}>{color.name}</p>
               <p className={'hex'}>{color.hex}</p>

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -265,12 +265,15 @@ const SwatchLink = styled(Link)`
   top: 0;
   left: 0;
   cursor: pointer;
-  color: ${colors.grey};
+  color: ${(props) =>
+    chroma.contrast(props.hex, colors.grey) > 2 ? colors.grey : colors.black};
+
 `
 
 const ComboLink = styled(Link)`
-  ${bigType};  
-  color: ${colors.grey};
+  ${bigType};
+  color: ${(props) =>
+    chroma.contrast(props.hex, colors.grey) > 2 ? colors.grey : colors.med_grey};
   margin-bottom: ${spacing.double_pad};
   display: inline-flex;
   &:hover {

--- a/src/views/Combination.js
+++ b/src/views/Combination.js
@@ -18,7 +18,7 @@ const Swatch = (props) =>
       <ComboWrapper>
         {props.colors.map((color, i) =>
           <ColorBar key={`${props.slug}-${i}`} style={{ backgroundColor: color.hex }}>
-            <SwatchLink to={`/swatch/${color.slug}`}>
+            <SwatchLink to={`/swatch/${color.slug}`} hex={color.hex}>
               <p className={'name'}>{color.name}</p>
             </SwatchLink>
           </ColorBar>

--- a/src/views/Swatch.js
+++ b/src/views/Swatch.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import chroma from 'chroma-js'
 import { swatchData, SwatchHeader, CopyHex } from './../components'
 import { flexColumn, ComboLink, ComboHex, bigType, ComboTitle } from './../styles'
 import { spacing, colors } from './../styles/theme.json'
@@ -16,10 +17,10 @@ const Swatch = (props) => {
         </ComboHex>
       </SwatchHeader>
       <SwatchSection style={{ backgroundColor: props.hex }}>
-        <ComboHeader><span>Combinations:</span></ComboHeader>
+        <ComboHeader hex={props.hex}><span>Combinations:</span></ComboHeader>
         <ComboList>
           {props.combinations.map((combo, i) =>
-            <ComboLink to={`/combination/${combo}`} key={`${props.slug}-${combo}`}>{combo}</ComboLink>
+            <ComboLink to={`/combination/${combo}`} key={`${props.slug}-${combo}`} hex={props.hex}>{combo}</ComboLink>
           )}
         </ComboList>
       </SwatchSection>
@@ -46,5 +47,6 @@ const ComboList = styled.menu`
 const ComboHeader = styled.h2`
   ${bigType};
   padding: 0 ${spacing.single_pad} ${spacing.single_pad};
-  color: ${colors.grey};
+  color: ${(props) =>
+    chroma.contrast(props.hex, colors.grey) > 2 ? colors.grey : colors.med_grey};
 `


### PR DESCRIPTION
Hi! I really like this project. I'll use this website for my design works from now on 😍 
However, I feel that the main text color is too bright to read in light swatches.

In this PR, I added some code to check the contrast between the text color and the swatch using `chroma.contrast` and switch the text color automatically.
https://gka.github.io/chroma.js/#chroma-contrast

## Screenshots

Landing page

![sanzo1](https://user-images.githubusercontent.com/1403842/83142989-3c44db80-a12c-11ea-9940-6df4a503af24.png)

`/swatch/glaucous-green`
![sanzo2](https://user-images.githubusercontent.com/1403842/83142913-20d9d080-a12c-11ea-9b97-a3da7bf4d7aa.png)

