### PR TITLE
Fix slugs + browse combinations

### DIFF
--- a/assets/colors.json
+++ b/assets/colors.json
@@ -2374,7 +2374,7 @@
      {  
         "index":85,
         "name":"Mars Brown / Tobacco",
-        "slug":"mars-brown-/-tobacco",
+        "slug":"mars-brown-tobacco",
         "cmyk_array":[  
            39,
            76,
@@ -4024,7 +4024,7 @@
      {  
         "index":143,
         "name":"Deep Violet / Plumbeous",
-        "slug":"deep-violet-/-plumbeous",
+        "slug":"deep-violet-plumbeous",
         "cmyk_array":[  
            61,
            52,

--- a/src/colors/colors.js
+++ b/src/colors/colors.js
@@ -17,7 +17,7 @@ const cv = (input) => {
 }
 
 const returnSlug = (title) => {
-  return title.replace(/\s+/g, '-').toLowerCase()
+  return title.replace('/', '').replace(/\s+/g, '-').toLowerCase()
 }
 
 export default (swatches) => {

--- a/src/views/Combination.js
+++ b/src/views/Combination.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { comboData, SwatchHeader, CopyHex } from './../components'
-import { flexRow, SwatchLink, ComboTitle, ComboHex } from './../styles'
+import { flexRow, SwatchLink, ComboTitle, ComboHex, ButtonLink } from './../styles'
 import { spacing, shared } from './../styles/theme.json'
 
 const Swatch = (props) =>
@@ -13,6 +13,14 @@ const Swatch = (props) =>
           <CopyHex hex={color.hex } key={`${props.slug}-title-${i}`}/>
         )}
       </ComboHex>
+      {props.slug !== '1' && (
+        <ButtonLink to={`/combination/${props.slug - 1}`}>
+          <span>&lt; Prev</span>
+        </ButtonLink>
+      )}
+      <ButtonLink to={`/combination/${parseInt(props.slug, 10) + 1}`}>
+        <span>Next &gt;</span>
+      </ButtonLink>
     </SwatchHeader>
     <ComboSection>
       <ComboWrapper>


### PR DESCRIPTION
- The slug for two colours have been fixed (they contained a slash in the name)
- Allow to browse colour combinations in sequence  (previous / next button)